### PR TITLE
Update ChangeSet.java

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -896,8 +896,10 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     }
 
     public boolean isInheritableIgnore() {
-        DatabaseChangeLog changeLog = getChangeLog();
-        return changeLog.isIncludeIgnore();
+       DatabaseChangeLog changeLog = getChangeLog();
+        if(null!=changeLog)
+        	return changeLog.isIncludeIgnore();
+        return false;
     }
 
     public Collection<ContextExpression> getInheritableContexts() {


### PR DESCRIPTION
This will throw null pointer if change changelog object is null. this object can be null if we got below issue in the code. 
"Error executing SQL SELECT COUNT(*) FROM DATABASECHANGELOG: ORA-00942: table or view does not exist"

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment Production 

**Liquibase Version**:  it started in 3.7.x onward.

**Liquibase Integration & Version**: Spring boot

**Liquibase Extension(s) & Version**:   it started in 3.7.x onward.

**Database Vendor & Version**: Oracle 

**Operating System Type & Version**: Windows 10

## Pull Request Type
Bug fix (non-breaking change which fixes an issue.)
https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838

## Description
When we get issue "Error executing SQL SELECT COUNT(*) FROM DATABASECHANGELOG: ORA-00942: table or view does not exist" in the code. this changelog object remain null. this method through null pointer issue. from this code. 

## Steps To Reproduce
[Error executing SQL SELECT COUNT(*) FROM DATABASECHANGELOG: ORA-00942: table or view does not exist](https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838)
## Actual Behavior
Code should no throw null pointer issue 

## Expected/Desired Behavior
A clear and concise description of what happens in the software **after** this pull request.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:


## Need Help?
Come chat with us in the [Liquibase Forum](https://forum.liquibase.org/).
https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838 Yes, to discuss this.
